### PR TITLE
Add Laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,12 @@
         }
     ],
     "require": {
-        "php": "^7.3|^7.4|^8.0|^8.1|^8.2|^8.3|^8.4"
+        "php": "^8.2",
+        "illuminate/support": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.16",
-        "orchestra/testbench": "^5.0",
-        "phpunit/phpunit": "^9.0",
-        "psalm/plugin-laravel": "^1.2",
-        "vimeo/psalm": "^3.11"
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "phpunit/phpunit": "^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {
@@ -36,10 +34,8 @@
         }
     },
     "scripts": {
-        "psalm": "vendor/bin/psalm",
         "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
-        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
## Summary

- **Simplified PHP constraint** to `^8.2` (required by Laravel 12, drops PHP 7.x support)
- **Added `illuminate/support`** constraint (`^10.0|^11.0|^12.0`) to explicitly declare framework compatibility
- **Updated dev dependencies**: `orchestra/testbench` to `^8.0|^9.0|^10.0`, `phpunit/phpunit` to `^10.0|^11.0`
- **Removed outdated dev dependencies** that don't support modern PHP: `vimeo/psalm`, `psalm/plugin-laravel`, `friendsofphp/php-cs-fixer` (and their associated composer scripts)

## Why

The package had no explicit Laravel framework version constraint and its dev tooling was pinned to versions incompatible with PHP 8.2+. These changes allow the package to be installed in Laravel 10, 11, and 12 projects while keeping the test infrastructure up to date.